### PR TITLE
fix/check-tmux-status-on-spawn

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ impl Tmux {
     }
 
     fn create_session(&self) -> eyre::Result<()> {
-        std::process::Command::new("tmux")
+        let status = std::process::Command::new("tmux")
             .args([
                 "new-session",
                 "-d",
@@ -99,6 +99,8 @@ impl Tmux {
             ])
             .status()
             .wrap_err("creating new session")?;
+
+        eyre::ensure!(status.success(), "creating new session failed");
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ impl Tmux {
                 "-c",
                 &self.path.display().to_string(),
             ])
-            .spawn()
+            .status()
             .wrap_err("creating new session")?;
         Ok(())
     }


### PR DESCRIPTION
- Replace using Command::new(...).status() without checking the result by capturing the spawned process status to avoid hiding failures.
- Switch to spawn + wait pattern to prevent a race condition when creating a new tmux session.
- Ensure tmux command exit status is validated and return a clear (eyre::!) if tmux exits non‑zero.