### PR TITLE
Support direct path switching via --path flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "listprojects"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "listprojects"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 
 [dependencies]

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
-rust = { version = "beta", components = "rust-src,rust-analyzer" }
+rust = { version = "beta", components = "rust-src" }
+rust-analyzer = "latest"

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,10 @@ struct Args {
     /// Non-interactive mode: print all found directories to stdout
     #[clap(short, long)]
     list: bool,
+
+    /// Assume the project is given on the command line and just create/reuse a tmux session
+    #[clap(short, long)]
+    path: Option<String>,
 }
 
 fn compute_session_name(path: impl AsRef<Path>) -> String {
@@ -111,6 +115,17 @@ impl Tmux {
     }
 }
 
+fn expand_user(given: impl AsRef<str>) -> eyre::Result<PathBuf> {
+    let given = given.as_ref();
+    if !given.contains("~") {
+        return Ok(PathBuf::from(given));
+    }
+
+    let home_dir = std::env::home_dir().ok_or_eyre("No home dir found")?;
+    let s = given.replace("~", &home_dir.display().to_string());
+    Ok(PathBuf::from(s))
+}
+
 fn main() -> eyre::Result<()> {
     color_eyre::install().wrap_err("Installing color-eyre handler")?;
     let args = Args::parse();
@@ -121,6 +136,18 @@ fn main() -> eyre::Result<()> {
     {
         todo!()
     };
+
+    // shortcut - if the project path is specified on the command line then just switch to that
+    // project
+    if let Some(path) = args.path {
+        let full_path = expand_user(path)
+            .context("failed to expand ~ for user directory")?
+            .canonicalize()
+            .wrap_err("Given path does not exist")?;
+        let session = Tmux::new(full_path);
+        session.activate();
+        return Ok(());
+    }
 
     let home = dirs::home_dir().ok_or_else(|| eyre::eyre!("Calculating home directory"))?;
     let roots = args


### PR DESCRIPTION
## Summary
- Add `--path` flag to directly create/switch to a tmux session for a given project path, bypassing the fuzzy finder
- Supports `~` expansion in the provided path
- Bump version to reflect new feature

## Test plan
- [ ] `cargo run -- --path ~/dev/listprojects` switches to/creates tmux session
- [ ] `cargo run -- --path .` works with relative paths
- [ ] `cargo run` without `--path` still works as before