### PR TITLE
feat: add frecency-based sorting for project selection

### DIFF
--- a/openspec/changes/archive/2026-03-18-frecency-sorting/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-18-frecency-sorting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-18

--- a/openspec/changes/archive/2026-03-18-frecency-sorting/design.md
+++ b/openspec/changes/archive/2026-03-18-frecency-sorting/design.md
@@ -1,0 +1,70 @@
+## Context
+
+`listprojects` discovers git repositories and presents them via skim for interactive selection. Currently, items are stored in a `HashSet<PathBuf>` and arrive at skim in arbitrary order. The user wants frequently and recently used projects to appear nearest the cursor (bottom of the list in skim's default layout).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Sort projects by frecency so the most relevant ones are nearest the cursor
+- Persist frecency data in the existing cache file with backwards-compatible format
+- Update scores on every project selection (interactive and `--path` modes)
+
+**Non-Goals:**
+- Configurable half-life value (hardcode a sensible default)
+- Frecency-aware fuzzy matching (skim still does its own ranking when the user types a query)
+- Migrating to a database or separate storage format
+
+## Decisions
+
+### 1. Algorithm: Half-life exponential decay
+
+**Choice:** `score = old_score × 2^(-Δt / half_life) + 1.0`
+
+**Alternatives considered:**
+- Zoxide-style discrete time buckets — simpler but creates score discontinuities at bucket boundaries
+- Pure frequency counting — no recency component, stale projects stay at top forever
+
+**Rationale:** Half-life decay is smooth, stores only two values per item (score + timestamp), and naturally ages out unused projects. The formula compresses the full visit history into a single running score.
+
+### 2. Half-life value: 3 days (259200 seconds)
+
+A visit from 3 days ago contributes half as much as a visit right now. This is responsive enough for a project switcher where daily usage patterns matter.
+
+### 3. Storage: Extend cache.txt with tab-separated fields
+
+**Format:** `path\tscore\tlast_accessed_epoch`
+
+Example:
+```
+/home/simon/dev/listprojects	4.200000	1710700800
+/home/simon/dev/other-project	1.500000	1710500000
+/home/simon/work/new-thing
+```
+
+**Alternatives considered:**
+- Separate JSON file — cleaner separation but adds file management complexity
+- SQLite — far too heavy for this use case
+
+**Rationale:** Tab-separated extends naturally. Lines without score data (no tabs, or from old format) parse as path-only with score 0. No new files or dependencies needed.
+
+### 4. Data structure: Replace HashSet with HashMap
+
+Change `HashSet<PathBuf>` to `HashMap<PathBuf, FrecencyEntry>` where `FrecencyEntry` holds `score: f64` and `last_accessed: Option<u64>` (epoch seconds).
+
+### 5. Sort order for skim
+
+Send items to skim sorted by score **descending** — highest scores first. In skim's default bottom-up layout, first-sent items appear at the bottom (nearest cursor). This means most-used projects are immediately accessible.
+
+### 6. Initial score for new projects
+
+Newly discovered projects get score `0.1`. This puts them below any project the user has actually selected (minimum score after one visit ≈ 1.0) but above zero, keeping them visible.
+
+### 7. When to update scores
+
+Score is updated when a project is **selected** — either via interactive skim selection or via `--path` flag. The cache must be loaded, the score updated, and the cache saved in both paths.
+
+## Risks / Trade-offs
+
+- **Floating-point drift**: After many updates, f64 scores could accumulate precision errors → Negligible for this use case; scores naturally stay small due to decay
+- **Cache file size**: Adding two fields per line increases file size → Minimal impact, typically <100 projects
+- **Background-discovered items arrive unsorted**: New items from the walker thread are sent to skim as discovered and can't be pre-sorted → Acceptable since these are new/uncached projects with score 0.1 and will appear at the top (far from cursor), which is correct behavior

--- a/openspec/changes/archive/2026-03-18-frecency-sorting/proposal.md
+++ b/openspec/changes/archive/2026-03-18-frecency-sorting/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Projects are currently displayed in arbitrary order (hash-set iteration order for cached items, parallel walk order for new discoveries). This makes it hard to quickly select frequently-used projects without fuzzy searching every time. Sorting by frecency (frequency + recency) puts the most relevant projects nearest the cursor.
+
+## What Changes
+
+- Extend `cache.txt` format to store a frecency score and last-accessed timestamp per path (tab-separated: `path\tscore\ttimestamp`)
+- Implement half-life decay scoring: `score = old_score × 2^(-Δt / half_life) + 1.0` on each project selection
+- Sort cached items by score (descending) before sending to skim, so highest-scored items appear nearest the cursor
+- Assign a small initial score (e.g. 0.1) to newly discovered projects so they appear below used projects but aren't invisible
+- Update the score on project selection (both interactive and `--path` modes) and persist to disk
+- Backwards-compatible parsing: lines without score/timestamp data are treated as score 0
+
+## Capabilities
+
+### New Capabilities
+- `frecency-scoring`: Half-life decay algorithm for computing and updating project frecency scores
+- `sorted-display`: Ordering of projects by frecency score when presented to the user
+
+### Modified Capabilities
+
+## Impact
+
+- `disk_cache.rs`: Major changes — new data structure (score + timestamp per entry), extended file format parsing/writing, sorted output
+- `main.rs`: Update selection handler to record a visit (update score) before saving cache; ensure `--path` mode also records visits
+- Cache file format: Extended but backwards-compatible (old single-path lines still parse)

--- a/openspec/changes/archive/2026-03-18-frecency-sorting/specs/frecency-scoring/spec.md
+++ b/openspec/changes/archive/2026-03-18-frecency-sorting/specs/frecency-scoring/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Half-life decay scoring
+The system SHALL compute frecency scores using the formula `new_score = old_score × 2^(-Δt / half_life) + 1.0`, where `Δt` is the elapsed time since the last access in seconds and `half_life` is 259200 seconds (3 days).
+
+#### Scenario: First visit to a project
+- **WHEN** a project with no prior score (score 0, no last_accessed) is selected
+- **THEN** the project's score SHALL be set to 1.0 and last_accessed SHALL be set to the current time
+
+#### Scenario: Repeat visit to a recently used project
+- **WHEN** a project with score 4.0 and last_accessed 1 hour ago is selected
+- **THEN** the score SHALL be updated to approximately `4.0 × 2^(-3600/259200) + 1.0 ≈ 4.96` and last_accessed SHALL be updated to the current time
+
+#### Scenario: Visit to a project not used in a long time
+- **WHEN** a project with score 4.0 and last_accessed 30 days ago is selected
+- **THEN** the score SHALL be updated to approximately `4.0 × 2^(-2592000/259200) + 1.0 ≈ 1.004` and last_accessed SHALL be updated to the current time
+
+### Requirement: Score update on interactive selection
+The system SHALL update the frecency score of a project when the user selects it via the interactive fuzzy finder.
+
+#### Scenario: User selects project in skim
+- **WHEN** the user selects a project from the skim interface
+- **THEN** the system SHALL update that project's frecency score before saving the cache
+
+### Requirement: Score update on direct path selection
+The system SHALL update the frecency score of a project when the user selects it via the `--path` flag.
+
+#### Scenario: User uses --path flag
+- **WHEN** the user runs `listprojects --path ~/dev/myproject`
+- **THEN** the system SHALL load the cache, update the frecency score for that path, and save the cache
+
+### Requirement: Initial score for new projects
+The system SHALL assign a score of 0.1 to newly discovered projects that have never been selected.
+
+#### Scenario: New project discovered during directory walk
+- **WHEN** a new git repository is found that is not in the cache
+- **THEN** it SHALL be added to the cache with score 0.1 and no last_accessed timestamp
+
+### Requirement: Persistent storage of frecency data
+The system SHALL store frecency scores and last-accessed timestamps in the cache file using tab-separated format: `path\tscore\tlast_accessed_epoch`.
+
+#### Scenario: Cache file with frecency data
+- **WHEN** the cache is saved to disk
+- **THEN** each entry SHALL be written as `path\tscore\tlast_accessed_epoch` (one per line)
+
+#### Scenario: Backwards-compatible parsing
+- **WHEN** the cache file contains lines with only a path (no tabs)
+- **THEN** the system SHALL parse them as entries with score 0.0 and no last_accessed timestamp

--- a/openspec/changes/archive/2026-03-18-frecency-sorting/specs/sorted-display/spec.md
+++ b/openspec/changes/archive/2026-03-18-frecency-sorting/specs/sorted-display/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Cached items sorted by frecency score
+The system SHALL send cached items to the skim fuzzy finder sorted by frecency score in descending order (highest score first).
+
+#### Scenario: Prepopulating skim with sorted items
+- **WHEN** cached items are sent to skim during startup
+- **THEN** items SHALL be sent in descending order of their current frecency score (computed at query time using the half-life decay formula against the current time)
+
+#### Scenario: Most-used project nearest cursor
+- **WHEN** the skim interface is displayed with default layout
+- **THEN** the highest-scored project SHALL appear at the bottom of the list (nearest the cursor), because skim places first-received items at the bottom
+
+### Requirement: Background-discovered items use initial score
+The system SHALL send newly discovered items (from the background directory walk) to skim as they are found, without re-sorting existing items.
+
+#### Scenario: New project found during background scan
+- **WHEN** a new project is discovered by the background walker
+- **THEN** it SHALL be sent to skim immediately with its initial score of 0.1, appearing above (further from cursor than) previously scored items

--- a/openspec/changes/archive/2026-03-18-frecency-sorting/tasks.md
+++ b/openspec/changes/archive/2026-03-18-frecency-sorting/tasks.md
@@ -1,0 +1,27 @@
+## 1. Data Model
+
+- [x] 1.1 Add `FrecencyEntry` struct with `score: f64` and `last_accessed: Option<u64>` fields to `disk_cache.rs`
+- [x] 1.2 Replace `HashSet<PathBuf>` with `HashMap<PathBuf, FrecencyEntry>` in the `Cache` struct
+- [x] 1.3 Add a `record_visit(&mut self, path: &Path)` method that applies the half-life decay formula and updates the entry
+
+## 2. Cache File Format
+
+- [x] 2.1 Update `Cache::new()` to parse tab-separated `path\tscore\ttimestamp` lines, falling back to score 0.0 for plain path lines
+- [x] 2.2 Update `save_items()` to write entries in `path\tscore\ttimestamp` format
+- [x] 2.3 Set initial score to 0.1 for newly discovered projects in `add_to_cache()`
+
+## 3. Sorted Display
+
+- [x] 3.1 Update `prepopulate_with()` to sort items by current frecency score (recomputed at query time) in descending order before sending to skim
+- [x] 3.2 Verify that in `--list` mode, output is also sorted by frecency score
+
+## 4. Score Updates on Selection
+
+- [x] 4.1 In the interactive selection path (`main.rs`), call `record_visit()` on the chosen project before saving the cache
+- [x] 4.2 In the `--path` path (`main.rs`), load the cache, call `record_visit()` on the given path, and save the cache
+
+## 5. Tests
+
+- [x] 5.1 Test half-life decay formula: verify score computation for first visit, recent revisit, and long-ago revisit
+- [x] 5.2 Test cache parsing: verify backwards-compatible parsing of plain path lines and tab-separated lines
+- [x] 5.3 Test cache serialization: verify entries are written in the correct tab-separated format

--- a/openspec/specs/frecency-scoring/spec.md
+++ b/openspec/specs/frecency-scoring/spec.md
@@ -1,0 +1,46 @@
+### Requirement: Half-life decay scoring
+The system SHALL compute frecency scores using the formula `new_score = old_score × 2^(-Δt / half_life) + 1.0`, where `Δt` is the elapsed time since the last access in seconds and `half_life` is 259200 seconds (3 days).
+
+#### Scenario: First visit to a project
+- **WHEN** a project with no prior score (score 0, no last_accessed) is selected
+- **THEN** the project's score SHALL be set to 1.0 and last_accessed SHALL be set to the current time
+
+#### Scenario: Repeat visit to a recently used project
+- **WHEN** a project with score 4.0 and last_accessed 1 hour ago is selected
+- **THEN** the score SHALL be updated to approximately `4.0 × 2^(-3600/259200) + 1.0 ≈ 4.96` and last_accessed SHALL be updated to the current time
+
+#### Scenario: Visit to a project not used in a long time
+- **WHEN** a project with score 4.0 and last_accessed 30 days ago is selected
+- **THEN** the score SHALL be updated to approximately `4.0 × 2^(-2592000/259200) + 1.0 ≈ 1.004` and last_accessed SHALL be updated to the current time
+
+### Requirement: Score update on interactive selection
+The system SHALL update the frecency score of a project when the user selects it via the interactive fuzzy finder.
+
+#### Scenario: User selects project in skim
+- **WHEN** the user selects a project from the skim interface
+- **THEN** the system SHALL update that project's frecency score before saving the cache
+
+### Requirement: Score update on direct path selection
+The system SHALL update the frecency score of a project when the user selects it via the `--path` flag.
+
+#### Scenario: User uses --path flag
+- **WHEN** the user runs `listprojects --path ~/dev/myproject`
+- **THEN** the system SHALL load the cache, update the frecency score for that path, and save the cache
+
+### Requirement: Initial score for new projects
+The system SHALL assign a score of 0.1 to newly discovered projects that have never been selected.
+
+#### Scenario: New project discovered during directory walk
+- **WHEN** a new git repository is found that is not in the cache
+- **THEN** it SHALL be added to the cache with score 0.1 and no last_accessed timestamp
+
+### Requirement: Persistent storage of frecency data
+The system SHALL store frecency scores and last-accessed timestamps in the cache file using tab-separated format: `path\tscore\tlast_accessed_epoch`.
+
+#### Scenario: Cache file with frecency data
+- **WHEN** the cache is saved to disk
+- **THEN** each entry SHALL be written as `path\tscore\tlast_accessed_epoch` (one per line)
+
+#### Scenario: Backwards-compatible parsing
+- **WHEN** the cache file contains lines with only a path (no tabs)
+- **THEN** the system SHALL parse them as entries with score 0.0 and no last_accessed timestamp

--- a/openspec/specs/sorted-display/spec.md
+++ b/openspec/specs/sorted-display/spec.md
@@ -1,0 +1,17 @@
+### Requirement: Cached items sorted by frecency score
+The system SHALL send cached items to the skim fuzzy finder sorted by frecency score in descending order (highest score first).
+
+#### Scenario: Prepopulating skim with sorted items
+- **WHEN** cached items are sent to skim during startup
+- **THEN** items SHALL be sent in descending order of their current frecency score (computed at query time using the half-life decay formula against the current time)
+
+#### Scenario: Most-used project nearest cursor
+- **WHEN** the skim interface is displayed with default layout
+- **THEN** the highest-scored project SHALL appear at the bottom of the list (nearest the cursor), because skim places first-received items at the bottom
+
+### Requirement: Background-discovered items use initial score
+The system SHALL send newly discovered items (from the background directory walk) to skim as they are found, without re-sorting existing items.
+
+#### Scenario: New project found during background scan
+- **WHEN** a new project is discovered by the background walker
+- **THEN** it SHALL be sent to skim immediately with its initial score of 0.1, appearing above (further from cursor than) previously scored items

--- a/src/disk_cache.rs
+++ b/src/disk_cache.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     io::{self, Write},
     path::{Path, PathBuf},
     sync::Arc,
@@ -8,6 +8,41 @@ use std::{
 use skim::{SkimItem, SkimItemSender};
 
 use crate::SelectablePath;
+
+const HALF_LIFE_SECS: f64 = 259_200.0; // 3 days
+
+fn now_epoch() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time before Unix epoch")
+        .as_secs()
+}
+
+#[derive(Clone, Debug)]
+pub struct FrecencyEntry {
+    pub score: f64,
+    pub last_accessed: Option<u64>,
+}
+
+impl FrecencyEntry {
+    pub fn new(score: f64, last_accessed: Option<u64>) -> Self {
+        Self {
+            score,
+            last_accessed,
+        }
+    }
+
+    /// Compute the current effective score by applying time decay from last_accessed to now.
+    pub fn current_score(&self, now: u64) -> f64 {
+        match self.last_accessed {
+            Some(ts) => {
+                let dt = now.saturating_sub(ts) as f64;
+                self.score * (2.0_f64).powf(-dt / HALF_LIFE_SECS)
+            }
+            None => self.score,
+        }
+    }
+}
 
 fn cache_filename() -> PathBuf {
     let cache_dir = dirs::cache_dir()
@@ -21,7 +56,7 @@ fn cache_filename() -> PathBuf {
 
 #[derive(Clone)]
 pub struct Cache {
-    items: HashSet<PathBuf>,
+    items: HashMap<PathBuf, FrecencyEntry>,
 }
 
 impl Cache {
@@ -32,10 +67,30 @@ impl Cache {
                 std::fs::read_to_string(&cache_filename).expect("reading cache contents");
             contents
                 .lines()
-                .map(PathBuf::from)
-                .collect::<HashSet<PathBuf>>()
+                .filter(|line| !line.is_empty())
+                .map(|line| {
+                    // Format: path\tscore\ttimestamp
+                    // Note: paths containing literal tab characters are not supported.
+                    let parts: Vec<&str> = line.split('\t').collect();
+                    match parts.len() {
+                        3 => {
+                            let path = PathBuf::from(parts[0]);
+                            let score = parts[1].parse::<f64>().unwrap_or(0.0);
+                            let last_accessed = parts[2].parse::<u64>().ok();
+                            (path, FrecencyEntry::new(score, last_accessed))
+                        }
+                        2 => {
+                            let path = PathBuf::from(parts[0]);
+                            let score = parts[1].parse::<f64>().unwrap_or(0.0);
+                            (path, FrecencyEntry::new(score, None))
+                        }
+                        // 1 field = plain path (old format), >3 fields = malformed, treat as path
+                        _ => (PathBuf::from(line), FrecencyEntry::new(0.0, None)),
+                    }
+                })
+                .collect::<HashMap<PathBuf, FrecencyEntry>>()
         } else {
-            HashSet::new()
+            HashMap::new()
         };
 
         Cache { items }
@@ -43,14 +98,22 @@ impl Cache {
 
     pub fn clear(&mut self) -> Result<(), io::Error> {
         self.items.clear();
-        let new_items = std::iter::empty();
-        self.save_items(new_items, cache_filename());
+        self.save_items_to(cache_filename());
         Ok(())
     }
 
-    /// Implementation for prepopulating the cache with project names
+    /// Implementation for prepopulating the cache with project names.
+    /// Items are sorted by current frecency score descending (highest first),
+    /// so skim places the most-used projects nearest the cursor.
     pub fn prepopulate_with(&self, tx: SkimItemSender) {
-        for p in &self.items {
+        let now = now_epoch();
+        let mut sorted: Vec<_> = self.items.iter().collect();
+        sorted.sort_by(|a, b| {
+            b.1.current_score(now)
+                .partial_cmp(&a.1.current_score(now))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        for (p, _) in sorted {
             let item: Arc<dyn SkimItem> = Arc::new(SelectablePath { path: p.clone() });
             let _ = tx.send(item);
         }
@@ -58,20 +121,45 @@ impl Cache {
 
     /// Add an item to the cache if not already present, and return true if the cache was updated
     pub fn add_to_cache(&mut self, value: impl Into<PathBuf>) -> bool {
-        self.items.insert(value.into())
+        let path = value.into();
+        if self.items.contains_key(&path) {
+            false
+        } else {
+            self.items.insert(path, FrecencyEntry::new(0.1, None));
+            true
+        }
+    }
+
+    /// Record a visit to a project, updating its frecency score.
+    pub fn record_visit(&mut self, path: &Path) {
+        let now = now_epoch();
+        let entry = self
+            .items
+            .entry(path.to_path_buf())
+            .or_insert_with(|| FrecencyEntry::new(0.0, None));
+        let decayed = entry.current_score(now);
+        entry.score = decayed + 1.0;
+        entry.last_accessed = Some(now);
     }
 
     pub fn save(&self) -> Result<(), io::Error> {
-        // Implementation for saving the cache to disk
-        self.save_items(self.items.iter().cloned(), cache_filename());
+        self.save_items_to(cache_filename());
         Ok(())
     }
 
-    fn save_items(&self, items: impl Iterator<Item = PathBuf>, output_path: impl AsRef<Path>) {
-        let items: Vec<_> = items.collect();
+    fn save_items_to(&self, output_path: impl AsRef<Path>) {
         let mut f = std::fs::File::create(output_path).expect("creating cache file");
-        for item in items {
-            writeln!(f, "{}", item.display()).expect("writing item to cache file");
+        for (path, entry) in &self.items {
+            match entry.last_accessed {
+                Some(ts) => {
+                    writeln!(f, "{}\t{:.6}\t{}", path.display(), entry.score, ts)
+                        .expect("writing item to cache file");
+                }
+                None => {
+                    writeln!(f, "{}\t{:.6}", path.display(), entry.score)
+                        .expect("writing item to cache file");
+                }
+            }
         }
         f.flush().expect("flushing cache file");
     }
@@ -80,5 +168,278 @@ impl Cache {
 impl Drop for Cache {
     fn drop(&mut self) {
         self.save().expect("Failed to save cache");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const HALF_LIFE: f64 = 259_200.0; // 3 days in seconds
+
+    // Helper: build a Cache from a file path (bypasses cache_filename())
+    fn cache_from_file(path: &Path) -> Cache {
+        let contents = std::fs::read_to_string(path).unwrap_or_default();
+        let items = contents
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(|line| {
+                let parts: Vec<&str> = line.split('\t').collect();
+                match parts.len() {
+                    3 => {
+                        let path = PathBuf::from(parts[0]);
+                        let score = parts[1].parse::<f64>().unwrap_or(0.0);
+                        let last_accessed = parts[2].parse::<u64>().ok();
+                        (path, FrecencyEntry::new(score, last_accessed))
+                    }
+                    2 => {
+                        let path = PathBuf::from(parts[0]);
+                        let score = parts[1].parse::<f64>().unwrap_or(0.0);
+                        (path, FrecencyEntry::new(score, None))
+                    }
+                    _ => (PathBuf::from(line), FrecencyEntry::new(0.0, None)),
+                }
+            })
+            .collect();
+        Cache { items }
+    }
+
+    // Helper: create a temp file with given contents, returns path
+    fn temp_cache_file(name: &str, contents: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!("listprojects_test_{}", name));
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    // ── Half-life decay formula tests ──
+
+    #[test]
+    fn first_visit_no_prior_score() {
+        // score=0, no last_accessed → decayed is 0.0, new score = 0.0 + 1.0 = 1.0
+        let entry = FrecencyEntry::new(0.0, None);
+        let now = 1_710_700_800;
+        let decayed = entry.current_score(now);
+        let new_score = decayed + 1.0;
+        assert!((new_score - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn revisit_after_one_hour() {
+        // score=4.0, Δt=3600s → 4.0 × 2^(-3600/259200) + 1.0 ≈ 4.962
+        let ts = 1_710_700_800;
+        let now = ts + 3600;
+        let entry = FrecencyEntry::new(4.0, Some(ts));
+        let decayed = entry.current_score(now);
+        let new_score = decayed + 1.0;
+        let expected = 4.0 * (2.0_f64).powf(-3600.0 / HALF_LIFE) + 1.0;
+        assert!(
+            (new_score - expected).abs() < 0.01,
+            "expected ~{expected}, got {new_score}"
+        );
+        assert!(
+            (new_score - 4.96).abs() < 0.05,
+            "expected ~4.96, got {new_score}"
+        );
+    }
+
+    #[test]
+    fn revisit_after_30_days() {
+        // score=4.0, Δt=2592000s → 4.0 × 2^(-2592000/259200) + 1.0 ≈ 1.004
+        let ts = 1_710_700_800;
+        let now = ts + 2_592_000;
+        let entry = FrecencyEntry::new(4.0, Some(ts));
+        let decayed = entry.current_score(now);
+        let new_score = decayed + 1.0;
+        let expected = 4.0 * (2.0_f64).powf(-2_592_000.0 / HALF_LIFE) + 1.0;
+        assert!(
+            (new_score - expected).abs() < 0.001,
+            "expected ~{expected}, got {new_score}"
+        );
+        assert!(
+            (new_score - 1.004).abs() < 0.01,
+            "expected ~1.004, got {new_score}"
+        );
+    }
+
+    #[test]
+    fn current_score_no_last_accessed_returns_raw() {
+        let entry = FrecencyEntry::new(3.5, None);
+        assert!((entry.current_score(9_999_999_999) - 3.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn current_score_dt_zero_returns_raw() {
+        let ts = 1_710_700_800;
+        let entry = FrecencyEntry::new(3.5, Some(ts));
+        // 2^0 = 1, so score * 1 = score
+        assert!((entry.current_score(ts) - 3.5).abs() < 1e-9);
+    }
+
+    // ── Cache parsing tests ──
+
+    #[test]
+    fn parse_plain_path_no_tabs() {
+        let path = temp_cache_file("plain_path", "/home/user/dev/project\n");
+        let cache = cache_from_file(&path);
+        let entry = cache.items.get(&PathBuf::from("/home/user/dev/project")).unwrap();
+        assert!((entry.score - 0.0).abs() < 1e-9);
+        assert!(entry.last_accessed.is_none());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn parse_tab_separated_line() {
+        let path = temp_cache_file(
+            "tab_sep",
+            "/home/user/dev/project\t4.200000\t1710700800\n",
+        );
+        let cache = cache_from_file(&path);
+        let entry = cache.items.get(&PathBuf::from("/home/user/dev/project")).unwrap();
+        assert!((entry.score - 4.2).abs() < 1e-6);
+        assert_eq!(entry.last_accessed, Some(1_710_700_800));
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn parse_score_no_timestamp() {
+        let path = temp_cache_file("score_no_ts", "/home/user/dev/project\t2.500000\n");
+        let cache = cache_from_file(&path);
+        let entry = cache.items.get(&PathBuf::from("/home/user/dev/project")).unwrap();
+        assert!((entry.score - 2.5).abs() < 1e-6);
+        assert!(entry.last_accessed.is_none());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn parse_empty_lines_skipped() {
+        let path = temp_cache_file(
+            "empty_lines",
+            "/home/a\n\n/home/b\n\n",
+        );
+        let cache = cache_from_file(&path);
+        assert_eq!(cache.items.len(), 2);
+        std::fs::remove_file(&path).ok();
+    }
+
+    // ── Cache serialization tests ──
+
+    #[test]
+    fn serialize_entry_with_timestamp() {
+        let mut items = HashMap::new();
+        items.insert(
+            PathBuf::from("/home/user/dev/proj"),
+            FrecencyEntry::new(4.2, Some(1_710_700_800)),
+        );
+        let cache = Cache { items };
+        let out = std::env::temp_dir().join("listprojects_test_ser_ts");
+        cache.save_items_to(&out);
+        let contents = std::fs::read_to_string(&out).unwrap();
+        assert!(contents.contains("/home/user/dev/proj\t4.200000\t1710700800"));
+        std::fs::remove_file(&out).ok();
+    }
+
+    #[test]
+    fn serialize_entry_without_timestamp() {
+        let mut items = HashMap::new();
+        items.insert(
+            PathBuf::from("/home/user/dev/proj"),
+            FrecencyEntry::new(0.1, None),
+        );
+        let cache = Cache { items };
+        let out = std::env::temp_dir().join("listprojects_test_ser_no_ts");
+        cache.save_items_to(&out);
+        let contents = std::fs::read_to_string(&out).unwrap();
+        let line = contents.trim();
+        assert_eq!(line, "/home/user/dev/proj\t0.100000");
+        std::fs::remove_file(&out).ok();
+    }
+
+    #[test]
+    fn round_trip_preserves_data() {
+        let mut items = HashMap::new();
+        items.insert(
+            PathBuf::from("/home/user/dev/alpha"),
+            FrecencyEntry::new(3.14, Some(1_710_700_800)),
+        );
+        items.insert(
+            PathBuf::from("/home/user/dev/beta"),
+            FrecencyEntry::new(0.5, None),
+        );
+        let cache = Cache { items };
+        let out = std::env::temp_dir().join("listprojects_test_roundtrip");
+        cache.save_items_to(&out);
+
+        let restored = cache_from_file(&out);
+        assert_eq!(restored.items.len(), 2);
+
+        let alpha = restored.items.get(&PathBuf::from("/home/user/dev/alpha")).unwrap();
+        assert!((alpha.score - 3.14).abs() < 0.001);
+        assert_eq!(alpha.last_accessed, Some(1_710_700_800));
+
+        let beta = restored.items.get(&PathBuf::from("/home/user/dev/beta")).unwrap();
+        assert!((beta.score - 0.5).abs() < 0.001);
+        assert!(beta.last_accessed.is_none());
+
+        std::fs::remove_file(&out).ok();
+    }
+
+    // ── add_to_cache tests ──
+
+    #[test]
+    fn add_to_cache_new_item_gets_initial_score() {
+        let mut cache = Cache {
+            items: HashMap::new(),
+        };
+        assert!(cache.add_to_cache("/home/user/dev/new_project"));
+        let entry = cache.items.get(&PathBuf::from("/home/user/dev/new_project")).unwrap();
+        assert!((entry.score - 0.1).abs() < 1e-9);
+        assert!(entry.last_accessed.is_none());
+    }
+
+    #[test]
+    fn add_to_cache_existing_item_returns_false() {
+        let mut cache = Cache {
+            items: HashMap::new(),
+        };
+        cache.add_to_cache("/home/user/dev/existing");
+        assert!(!cache.add_to_cache("/home/user/dev/existing"));
+    }
+
+    // ── record_visit tests ──
+
+    #[test]
+    fn record_visit_new_path_creates_entry_with_score_1() {
+        let mut cache = Cache {
+            items: HashMap::new(),
+        };
+        cache.record_visit(Path::new("/home/user/dev/fresh"));
+        let entry = cache.items.get(&PathBuf::from("/home/user/dev/fresh")).unwrap();
+        // or_insert gives score=0.0, current_score(now)=0.0, new = 0.0 + 1.0 = 1.0
+        assert!((entry.score - 1.0).abs() < 1e-9);
+        assert!(entry.last_accessed.is_some());
+    }
+
+    #[test]
+    fn record_visit_existing_path_applies_decay_plus_one() {
+        let mut items = HashMap::new();
+        let ts = now_epoch() - 3600; // 1 hour ago
+        items.insert(
+            PathBuf::from("/home/user/dev/proj"),
+            FrecencyEntry::new(4.0, Some(ts)),
+        );
+        let mut cache = Cache { items };
+        cache.record_visit(Path::new("/home/user/dev/proj"));
+        let entry = cache.items.get(&PathBuf::from("/home/user/dev/proj")).unwrap();
+        // decayed = 4.0 * 2^(-3600/259200) ≈ 3.962, new = decayed + 1.0 ≈ 4.962
+        let expected_decayed = 4.0 * (2.0_f64).powf(-3600.0 / HALF_LIFE);
+        assert!(
+            (entry.score - (expected_decayed + 1.0)).abs() < 0.01,
+            "expected ~{}, got {}",
+            expected_decayed + 1.0,
+            entry.score
+        );
+        assert!(entry.last_accessed.is_some());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,11 @@ fn main() -> eyre::Result<()> {
             .context("failed to expand ~ for user directory")?
             .canonicalize()
             .wrap_err("Given path does not exist")?;
+        {
+            let mut c = cache.lock().unwrap();
+            c.record_visit(&full_path);
+            c.save().unwrap();
+        }
         let session = Tmux::new(full_path);
         session.activate();
         return Ok(());
@@ -262,6 +267,12 @@ fn main() -> eyre::Result<()> {
         })
         .collect::<Vec<_>>();
     let chosen_path = items.first().unwrap();
+
+    {
+        let mut c = cache.lock().unwrap();
+        c.record_visit(chosen_path);
+        c.save().unwrap();
+    }
 
     let session = Tmux::new(chosen_path);
     session.activate();


### PR DESCRIPTION
## Summary

- Sort projects by frecency (frequency + recency) using half-life exponential decay scoring so the most-used projects appear nearest the cursor in the fuzzy finder
- Extend cache.txt format with tab-separated score and timestamp fields (backwards-compatible with old plain-path format)
- Record visits on both interactive selection and `--path` flag, persisting scores across runs

## Details

Uses the formula `score = old_score × 2^(-Δt / half_life) + 1.0` with a 3-day half-life. Newly discovered projects get an initial score of 0.1 so they appear below actively used projects. 17 unit tests covering the decay formula, cache parsing/serialization, and visit recording.

## Test plan

- [x] `cargo test` — 17/17 tests pass (decay formula, cache parsing, serialization, add_to_cache, record_visit)
- [x] `cargo check` — compiles cleanly
- [ ] Manual: run `listprojects`, select a project, verify cache updates with score
- [ ] Manual: run `listprojects --path ~/dev/foo`, verify cache records the visit
- [ ] Manual: run `listprojects` again, verify most-used project appears nearest cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)